### PR TITLE
Make piglins recognise golden items

### DIFF
--- a/src/main/resources/data/minecraft/tags/items/piglin_loved.json
+++ b/src/main/resources/data/minecraft/tags/items/piglin_loved.json
@@ -3,7 +3,7 @@
   "values": [
     "sandwichable:golden_kitchen_knife",
     "sandwichable:chopped_golden_carrot",
-	  "sandwichable:golden_apple_slices",
-	  "sandwichable:enchanted_golden_apple_slices"
+    "sandwichable:golden_apple_slices",
+    "sandwichable:enchanted_golden_apple_slices"
   ]
 }

--- a/src/main/resources/data/minecraft/tags/items/piglin_loved.json
+++ b/src/main/resources/data/minecraft/tags/items/piglin_loved.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "sandwichable:golden_kitchen_knife",
+    "sandwichable:chopped_golden_carrot",
+	  "sandwichable:golden_apple_slices",
+	  "sandwichable:enchanted_golden_apple_slices"
+  ]
+}


### PR DESCRIPTION
Quite simply, I noticed that Piglins currently don't give a rat's posterior about golden kitchen knives, sliced golden carrots, golden or enchanted golden apple slices, and so I added them to #minecraft:piglin_loved for ya.~