### PR TITLE
Add EMI Compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 		exclude(group: "com.terraformersmc")
 		exclude(group: "io.github.prospector")
 	}
+	modCompileOnly "dev.emi:emi:${emi_version}:api"
 	modApi "com.terraformersmc:modmenu:${project.modmenu_version}"
 
 	modApi("squeek.appleskin:appleskin-fabric:${project.appleskin_version}:api") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,7 @@ maven_group = io.github.foundationgames
 archives_base_name = sandwichable
 
 rei_version=9.0.493
+emi_version=0.7.3+1.19.2
 modmenu_version=4.0.0
 appleskin_version=mc1.19-2.4.0
 mealapi_version=0.3.1+1.19

--- a/src/main/java/io/github/foundationgames/sandwichable/common/CommonTags.java
+++ b/src/main/java/io/github/foundationgames/sandwichable/common/CommonTags.java
@@ -36,7 +36,6 @@ public class CommonTags {
     public static final TagKey<Item> COOKED_SALMON_FILET = t("cooked_salmon_filet");
     public static final TagKey<Item> DEFAULT_CHEESE_WHEEL = t("default_cheese_wheel");
     public static final TagKey<Item> DEFAULT_CHEESE_PIECE = t("default_cheese_piece");
-    public static final TagKey<Item> CUTTING_BOARDS = t("cutting_boards");
     /*public static final Map<Pair<CheeseType, Boolean>, TagKey<Item>> CHEESE_TAGS = Util.create(() -> {
         Map<Pair<CheeseType, Boolean>, TagKey<Item>> map = new HashMap<>();
         for(CheeseType type : CheeseType.values()) {

--- a/src/main/java/io/github/foundationgames/sandwichable/common/CommonTags.java
+++ b/src/main/java/io/github/foundationgames/sandwichable/common/CommonTags.java
@@ -36,6 +36,7 @@ public class CommonTags {
     public static final TagKey<Item> COOKED_SALMON_FILET = t("cooked_salmon_filet");
     public static final TagKey<Item> DEFAULT_CHEESE_WHEEL = t("default_cheese_wheel");
     public static final TagKey<Item> DEFAULT_CHEESE_PIECE = t("default_cheese_piece");
+    public static final TagKey<Item> CUTTING_BOARDS = t("cutting_boards");
     /*public static final Map<Pair<CheeseType, Boolean>, TagKey<Item>> CHEESE_TAGS = Util.create(() -> {
         Map<Pair<CheeseType, Boolean>, TagKey<Item>> map = new HashMap<>();
         for(CheeseType type : CheeseType.values()) {

--- a/src/main/java/io/github/foundationgames/sandwichable/plugin/emi/EmiCuttingRecipe.java
+++ b/src/main/java/io/github/foundationgames/sandwichable/plugin/emi/EmiCuttingRecipe.java
@@ -1,0 +1,75 @@
+package io.github.foundationgames.sandwichable.plugin.emi;
+
+import dev.emi.emi.api.recipe.EmiRecipe;
+import dev.emi.emi.api.recipe.EmiRecipeCategory;
+import dev.emi.emi.api.stack.EmiIngredient;
+import dev.emi.emi.api.stack.EmiStack;
+import dev.emi.emi.api.widget.WidgetHolder;
+import io.github.foundationgames.sandwichable.util.Util;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.Ingredient;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public class EmiCuttingRecipe implements EmiRecipe {
+	private final Identifier id;
+	private final EmiIngredient input;
+	private final EmiStack output;
+	private static final List<EmiIngredient> KNIVES = List.of(EmiIngredient.of(Arrays.stream(Util.getConfig().itemOptions.knives).map(p -> Identifier.tryParse(p.itemId)).filter(Objects::nonNull).map(Registry.ITEM::getOrEmpty).filter(Optional::isPresent).map(Optional::get).map(Item::getDefaultStack).map(EmiStack::of).toList()));
+
+	public EmiCuttingRecipe(Identifier id, Ingredient input, ItemStack result) {
+		this.id = id;
+		this.input = EmiIngredient.of(input);
+		this.output = EmiStack.of(result);
+	}
+
+	@Override
+	public EmiRecipeCategory getCategory() {
+		return SandwichableEMI.CUTTING_CATEGORY;
+	}
+
+	@Override
+	public @Nullable Identifier getId() {
+		return id;
+	}
+
+	@Override
+	public List<EmiIngredient> getInputs() {
+		return List.of(input);
+	}
+
+	@Override
+	public List<EmiIngredient> getCatalysts() {
+		return KNIVES;
+	}
+
+	@Override
+	public List<EmiStack> getOutputs() {
+		return List.of(output);
+	}
+
+	@Override
+	public int getDisplayWidth() {
+		return 134;
+	}
+
+	@Override
+	public int getDisplayHeight() {
+		return 40;
+	}
+
+	@Override
+	public void addWidgets(WidgetHolder widgets) {
+		widgets.addTexture(Util.id("textures/gui/cutting_recipe_rei.png"), 20, 0, 94, 39, 0, 0);
+		widgets.addSlot(input, 29, 8);
+		widgets.addSlot(EmiIngredient.of(KNIVES), 43, 14).drawBack(false);
+		widgets.addSlot(output, 92, 11).drawBack(false).recipeContext(this);
+	}
+}

--- a/src/main/java/io/github/foundationgames/sandwichable/plugin/emi/EmiToastingRecipe.java
+++ b/src/main/java/io/github/foundationgames/sandwichable/plugin/emi/EmiToastingRecipe.java
@@ -1,0 +1,68 @@
+package io.github.foundationgames.sandwichable.plugin.emi;
+
+import dev.emi.emi.api.recipe.EmiRecipe;
+import dev.emi.emi.api.recipe.EmiRecipeCategory;
+import dev.emi.emi.api.stack.EmiIngredient;
+import dev.emi.emi.api.stack.EmiStack;
+import dev.emi.emi.api.widget.WidgetHolder;
+import io.github.foundationgames.sandwichable.util.Util;
+import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.Ingredient;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class EmiToastingRecipe implements EmiRecipe {
+	public static final Text TOASTING_TIME = Text.translatable("category.sandwichable.toasting.time");
+	private final Identifier id;
+	private final EmiIngredient input;
+	private final EmiStack output;
+
+	public EmiToastingRecipe(Identifier id, Ingredient input, ItemStack result) {
+		this.id = id;
+		this.input = EmiIngredient.of(input);
+		this.output = EmiStack.of(result);
+	}
+
+	@Override
+	public EmiRecipeCategory getCategory() {
+		return SandwichableEMI.TOASTING_CATEGORY;
+	}
+
+	@Override
+	public @Nullable Identifier getId() {
+		return id;
+	}
+
+	@Override
+	public List<EmiIngredient> getInputs() {
+		return List.of(input);
+	}
+
+	@Override
+	public List<EmiStack> getOutputs() {
+		return List.of(output);
+	}
+
+	@Override
+	public int getDisplayWidth() {
+		return 134;
+	}
+
+	@Override
+	public int getDisplayHeight() {
+		return 40;
+	}
+
+	@Override
+	public void addWidgets(WidgetHolder widgets) {
+		widgets.addTexture(Util.id("textures/gui/toasting_recipe_rei.png"), 19, 10, 30, 22, 0, 0);
+		widgets.addTexture(Util.id("textures/gui/toasting_recipe_rei.png"), 85, 10, 30, 22, 30, 0);
+		widgets.addFillingArrow(56, 10, 12000);
+		widgets.addText(TOASTING_TIME, 51, 30, -12566464, false);
+		widgets.addSlot(input, 25, 7).drawBack(false);
+		widgets.addSlot(output, 91, 7).drawBack(false).recipeContext(this);
+	}
+}

--- a/src/main/java/io/github/foundationgames/sandwichable/plugin/emi/SandwichableEMI.java
+++ b/src/main/java/io/github/foundationgames/sandwichable/plugin/emi/SandwichableEMI.java
@@ -1,0 +1,43 @@
+package io.github.foundationgames.sandwichable.plugin.emi;
+
+import dev.emi.emi.api.EmiPlugin;
+import dev.emi.emi.api.EmiRegistry;
+import dev.emi.emi.api.recipe.EmiCraftingRecipe;
+import dev.emi.emi.api.recipe.EmiRecipeCategory;
+import dev.emi.emi.api.stack.EmiStack;
+import io.github.foundationgames.sandwichable.blocks.BlocksRegistry;
+import io.github.foundationgames.sandwichable.items.ItemsRegistry;
+import io.github.foundationgames.sandwichable.recipe.SandwichableRecipes;
+import io.github.foundationgames.sandwichable.recipe.special.AncientGrainBreadSliceRecipe;
+import io.github.foundationgames.sandwichable.recipe.special.ToastedAncientGrainBreadSliceRecipe;
+import io.github.foundationgames.sandwichable.util.Util;
+import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.Ingredient;
+
+import java.util.List;
+
+public class SandwichableEMI implements EmiPlugin {
+	public static final EmiRecipeCategory CUTTING_CATEGORY = new EmiRecipeCategory(Util.id("cutting"), EmiStack.of(new ItemStack(BlocksRegistry.OAK_CUTTING_BOARD).getItem()));
+	public static final EmiRecipeCategory TOASTING_CATEGORY = new EmiRecipeCategory(Util.id("toasting"), EmiStack.of(new ItemStack(BlocksRegistry.TOASTER).getItem()));
+
+	@Override
+	public void register(EmiRegistry registry) {
+		registry.addCategory(CUTTING_CATEGORY);
+		registry.addCategory(TOASTING_CATEGORY);
+		registry.addWorkstation(CUTTING_CATEGORY, EmiStack.of(new ItemStack(BlocksRegistry.OAK_CUTTING_BOARD).getItem()));
+		registry.addWorkstation(TOASTING_CATEGORY, EmiStack.of(new ItemStack(BlocksRegistry.TOASTER).getItem()));
+		registry.getRecipeManager().listAllOfType(SandwichableRecipes.CUTTING_RECIPE).forEach((cuttingRecipe -> {
+			if (!(cuttingRecipe instanceof AncientGrainBreadSliceRecipe)) {
+				registry.addRecipe(new EmiCuttingRecipe(cuttingRecipe.getId(), cuttingRecipe.getInput(), cuttingRecipe.getOutput()));
+			}
+		}));
+		registry.getRecipeManager().listAllOfType(SandwichableRecipes.TOASTING_RECIPE).forEach((toastingRecipe -> {
+			if (!(toastingRecipe instanceof ToastedAncientGrainBreadSliceRecipe)) {
+				registry.addRecipe(new EmiToastingRecipe(toastingRecipe.getId(), toastingRecipe.getInput(), toastingRecipe.getOutput()));
+			}
+		}));
+		registry.addRecipe(new EmiCraftingRecipe(List.of(EmiStack.of(ItemsRegistry.ANCIENT_GRAIN.getDefaultStack()), EmiStack.of(ItemsRegistry.ANCIENT_GRAIN.getDefaultStack()), EmiStack.of(ItemsRegistry.ANCIENT_GRAIN.getDefaultStack())), EmiStack.of(ItemsRegistry.ANCIENT_GRAIN_BREAD.getDefaultStack()), Util.id("crafting_special_ancientgrainbread"), true));
+		registry.addRecipe(new EmiCuttingRecipe(Util.id("cutting_special_ancientgrainbreadslice"), Ingredient.ofItems(ItemsRegistry.ANCIENT_GRAIN_BREAD), ItemsRegistry.ANCIENT_GRAIN_BREAD_SLICE.getDefaultStack()));
+		registry.addRecipe(new EmiToastingRecipe(Util.id("toasting_special_toastedancientgrainbreadslice"), Ingredient.ofItems(ItemsRegistry.ANCIENT_GRAIN_BREAD_SLICE), ItemsRegistry.TOASTED_ANCIENT_GRAIN_BREAD_SLICE.getDefaultStack()));
+	}
+}

--- a/src/main/java/io/github/foundationgames/sandwichable/plugin/emi/SandwichableEMI.java
+++ b/src/main/java/io/github/foundationgames/sandwichable/plugin/emi/SandwichableEMI.java
@@ -6,8 +6,8 @@ import dev.emi.emi.api.recipe.EmiCraftingRecipe;
 import dev.emi.emi.api.recipe.EmiRecipeCategory;
 import dev.emi.emi.api.stack.EmiIngredient;
 import dev.emi.emi.api.stack.EmiStack;
+import io.github.foundationgames.sandwichable.Sandwichable;
 import io.github.foundationgames.sandwichable.blocks.BlocksRegistry;
-import io.github.foundationgames.sandwichable.common.CommonTags;
 import io.github.foundationgames.sandwichable.items.ItemsRegistry;
 import io.github.foundationgames.sandwichable.recipe.SandwichableRecipes;
 import io.github.foundationgames.sandwichable.recipe.special.AncientGrainBreadSliceRecipe;
@@ -26,7 +26,7 @@ public class SandwichableEMI implements EmiPlugin {
 	public void register(EmiRegistry registry) {
 		registry.addCategory(CUTTING_CATEGORY);
 		registry.addCategory(TOASTING_CATEGORY);
-		registry.addWorkstation(CUTTING_CATEGORY, EmiIngredient.of(CommonTags.CUTTING_BOARDS));
+		registry.addWorkstation(CUTTING_CATEGORY, EmiIngredient.of(Sandwichable.CUTTING_BOARDS));
 		registry.addWorkstation(TOASTING_CATEGORY, EmiStack.of(new ItemStack(BlocksRegistry.TOASTER).getItem()));
 		registry.getRecipeManager().listAllOfType(SandwichableRecipes.CUTTING_RECIPE).forEach((cuttingRecipe -> {
 			if (!(cuttingRecipe instanceof AncientGrainBreadSliceRecipe)) {

--- a/src/main/java/io/github/foundationgames/sandwichable/plugin/emi/SandwichableEMI.java
+++ b/src/main/java/io/github/foundationgames/sandwichable/plugin/emi/SandwichableEMI.java
@@ -4,8 +4,10 @@ import dev.emi.emi.api.EmiPlugin;
 import dev.emi.emi.api.EmiRegistry;
 import dev.emi.emi.api.recipe.EmiCraftingRecipe;
 import dev.emi.emi.api.recipe.EmiRecipeCategory;
+import dev.emi.emi.api.stack.EmiIngredient;
 import dev.emi.emi.api.stack.EmiStack;
 import io.github.foundationgames.sandwichable.blocks.BlocksRegistry;
+import io.github.foundationgames.sandwichable.common.CommonTags;
 import io.github.foundationgames.sandwichable.items.ItemsRegistry;
 import io.github.foundationgames.sandwichable.recipe.SandwichableRecipes;
 import io.github.foundationgames.sandwichable.recipe.special.AncientGrainBreadSliceRecipe;
@@ -24,7 +26,7 @@ public class SandwichableEMI implements EmiPlugin {
 	public void register(EmiRegistry registry) {
 		registry.addCategory(CUTTING_CATEGORY);
 		registry.addCategory(TOASTING_CATEGORY);
-		registry.addWorkstation(CUTTING_CATEGORY, EmiStack.of(new ItemStack(BlocksRegistry.OAK_CUTTING_BOARD).getItem()));
+		registry.addWorkstation(CUTTING_CATEGORY, EmiIngredient.of(CommonTags.CUTTING_BOARDS));
 		registry.addWorkstation(TOASTING_CATEGORY, EmiStack.of(new ItemStack(BlocksRegistry.TOASTER).getItem()));
 		registry.getRecipeManager().listAllOfType(SandwichableRecipes.CUTTING_RECIPE).forEach((cuttingRecipe -> {
 			if (!(cuttingRecipe instanceof AncientGrainBreadSliceRecipe)) {

--- a/src/main/resources/assets/sandwichable/lang/en_us.json
+++ b/src/main/resources/assets/sandwichable/lang/en_us.json
@@ -339,5 +339,9 @@
 	"block.sandwichable.salty_sand.info": "An ore-like block found in beaches and oceans, which can be broken to obtain a Salt Rock and some sand.",
 	"block.sandwichable.salty_rocks.info": "An unobtainable block lining the edges of naturally generated salt pools. Water on top of this block will be saline, meaning a desalinator will work on top of this block.",
 	"block.sandwichable.salty_stone.info": "An unobtainable block lining the floor of naturally generated salt pools. Water on top of this block will be saline, meaning a desalinator will work on top of this block.",
-	"block.sandwichable.desalinator.info": "A machine used to extract salt from beach and ocean water. Is fueled by redstone dust as an item, unlike the Redstone Toaster, and can be waterlogged to fill its tank. Will produce salt if it is in a salty biome."
+	"block.sandwichable.desalinator.info": "A machine used to extract salt from beach and ocean water. Is fueled by redstone dust as an item, unlike the Redstone Toaster, and can be waterlogged to fill its tank. Will produce salt if it is in a salty biome.",
+
+	"emi.category.sandwichable.cutting": "Cutting",
+	"emi.category.sandwichable.toasting": "Toasting",
+	"tag.sandwichable.default_knives": "Kitchen Knives"
 }

--- a/src/main/resources/data/sandwichable/tags/items/default_knives.json
+++ b/src/main/resources/data/sandwichable/tags/items/default_knives.json
@@ -1,0 +1,10 @@
+{
+	"values": [
+		"sandwichable:stone_kitchen_knife",
+		"sandwichable:kitchen_knife",
+		"sandwichable:golden_kitchen_knife",
+		"sandwichable:diamond_kitchen_knife",
+		"sandwichable:netherite_kitchen_knife",
+		"sandwichable:glass_kitchen_knife"
+	]
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,6 +30,9 @@
 	"rei_client": [
       "io.github.foundationgames.sandwichable.plugin.rei.SandwichableREI"
     ],
+	"emi": [
+      "io.github.foundationgames.sandwichable.plugin.emi.SandwichableEMI"
+    ],
     "modmenu": [
       "io.github.foundationgames.sandwichable.plugin.SandwichableModMenu"
     ],


### PR DESCRIPTION
This adds an EMI plugin with similar functionality to the REI plugin.

Cutting Recipe:

![javaw_BqfmQgKM9Y](https://github.com/FoundationGames/Sandwichable/assets/55819817/ce4b74c8-2b5e-4496-980a-a9f55a99d18a)

Default Knife Tag: 

![javaw_7W6Dp4C8Oq](https://github.com/FoundationGames/Sandwichable/assets/55819817/ecbc6680-5e96-40a4-978b-23074e062e31)

Toasting Recipe:

![javaw_uJySu9iyuT](https://github.com/FoundationGames/Sandwichable/assets/55819817/3db5b297-36df-4d48-bace-40f17bcb4908)

Special Toasting Recipe (new!):

![javaw_USE9jrLZWO](https://github.com/FoundationGames/Sandwichable/assets/55819817/b946383e-b5c6-4302-83ae-380471671f80)

The screens are nearly identical to their REI counterparts, though I did move the toasting time text to fit EMI's lower max width.

The default_knives tag is added purely for the client-side translation when using default configs. Doesn't actually do anything.